### PR TITLE
Change sampling error to warning

### DIFF
--- a/R/local_truck_generation.R
+++ b/R/local_truck_generation.R
@@ -92,7 +92,7 @@ local_truck_generation <- function(synthetic_firms, generation_probabilities,
       if (trials>as.integer(max_resampling_attempts)) {
         error_message <- paste("Max resampling exceeded while working on", t,
           "generation")
-        stop(error_message)
+        warning(error_message)
       }
 
       # Calculate our target


### PR DESCRIPTION
In cases where it does not sample within the threshold, the number of trips is likely to be so low that the difference between 1% error and 5% is only a handful of trucks. I'm willing to live with a warning in this case.